### PR TITLE
Fix typo in unet_segment_weeds

### DIFF
--- a/src/unet_segment_weeds.py
+++ b/src/unet_segment_weeds.py
@@ -193,12 +193,12 @@ class UNetInference:
             log.error(f"No bounding box found for {image_path}. Skipping.")
             return 
         
-        categroy = metadata["category"]
-        if categroy is None:
-            log.error(f"No Category found for {image_path}. Skipping.")
+        category = metadata["category"]
+        if category is None:
+            log.error(f"No category found for {image_path}. Skipping.")
             return
-        
-        class_id = categroy["class_id"]
+
+        class_id = category["class_id"]
         
         # Add min/max coordinates to the bounding box
         bx = self.get_bbox_minmax(bbox)


### PR DESCRIPTION
## Summary
- rename `categroy` variable to `category`
- update reference and logging in `process_image`

## Testing
- `python -m py_compile src/unet_segment_weeds.py`


------
https://chatgpt.com/codex/tasks/task_e_683f9ee6215083338f7d7df6ae92aef9