### PR TITLE
Fix package_cvat when no images present

### DIFF
--- a/src/utils/cvat_scripts/package_cvat.py
+++ b/src/utils/cvat_scripts/package_cvat.py
@@ -56,7 +56,12 @@ class PackageCVAT:
         - Zips the entire CVAT package directory and deletes the temp folder
         """
         logging.info(f"Processing images and masks for species: {self.species}")
-        for image_path in self.cropout_images:
+        image_paths = list(self.cropout_images)
+        if not image_paths:
+            logging.warning("No images found. Skipping CVAT package creation.")
+            return
+
+        for image_path in image_paths:
             # Convert image to .png and copy to CVAT directory
             new_image_path = self.cvat_img_dir / image_path.name
             shutil.copy(str(image_path), new_image_path)

--- a/tests/test_package_cvat.py
+++ b/tests/test_package_cvat.py
@@ -1,0 +1,22 @@
+import logging
+from pathlib import Path
+
+from src.utils.cvat_scripts.package_cvat import PackageCVAT
+
+
+def test_no_images(tmp_path, caplog):
+    species_dir = tmp_path / "species"
+    cutouts = species_dir / "cutouts"
+    cutouts.mkdir(parents=True)
+
+    package = PackageCVAT(species_dir)
+
+    caplog.set_level(logging.WARNING)
+    package.process_images_and_masks()
+
+    expected_zip = species_dir / f"{package.species}_cvat_package.zip"
+    assert not expected_zip.exists()
+    assert any(
+        rec.levelno == logging.WARNING and "No images found" in rec.message
+        for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary
- handle empty dataset in `process_images_and_masks`
- warn when no images found and skip archive creation
- cover with a unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa6cbd9ac83338836870b23e886f1