### PR TITLE
Fix CVAT mapping file path

### DIFF
--- a/src/utils/cvat_scripts/package_cvat.py
+++ b/src/utils/cvat_scripts/package_cvat.py
@@ -63,7 +63,7 @@ class PackageCVAT:
 
             # Write line in txt file linking image and mask
             with open(self.images_annot_file_path, 'a') as f:
-                f.write(f"/{self.species}/{image_path.name} {self.species}annot/{image_path.stem}.png\n")
+                f.write(f"{self.species}/{image_path.name} {self.species}annot/{image_path.stem}.png\n")
 
             # Convert grayscale mask to 3D and save
             mask_3d = self.create_3d_masks(image_path)


### PR DESCRIPTION
## Summary
- fix mapping output in `PackageCVAT.process_images_and_masks` so the leading slash is removed

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fa6c15b2083338c8f2a6535005521